### PR TITLE
Fix: Improper handling of conditional stack effect for BB_TEST_ITER

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -267,9 +267,9 @@ extern int _PyStaticCode_Init(PyCodeObject *co);
 //   This flag is used to determine if the type context of a new bb
 //   requires a stack element to be popped.
 #define BB_TEST(gen_bb_is_successor, gen_bb_requires_pop) \
-    ((gen_bb_is_successor << 1) + gen_bb_requires_pop)
-#define BB_TEST_IS_SUCCESSOR(bb_test) (bb_test >> 1)
-#define BB_TEST_IS_REQUIRES_POP(bb_test) (bb_test & 1) 
+    (((gen_bb_is_successor) << 1) + (gen_bb_requires_pop))
+#define BB_TEST_IS_SUCCESSOR(bb_test) ((bb_test) >> 1)
+#define BB_TEST_IS_REQUIRES_POP(bb_test) ((bb_test) & 1) 
 
 extern _Py_CODEUNIT *_PyCode_Tier2Warmup(struct _PyInterpreterFrame *,
     _Py_CODEUNIT *);

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -257,6 +257,20 @@ extern void _PyStaticCode_Fini(PyCodeObject *co);
 extern int _PyStaticCode_Init(PyCodeObject *co);
 
 /* Tier 2 interpreter */
+
+// gen_bb_is_successor:
+//   true = successor
+//   false = alternate
+// gen_bb_requires_pop:
+//   For tier2 type propagation, handling of jump instructions with
+//   runtime-dependent stack effect.
+//   This flag is used to determine if the type context of a new bb
+//   requires a stack element to be popped.
+#define BB_TEST(gen_bb_is_successor, gen_bb_requires_pop) \
+    ((gen_bb_is_successor << 1) + gen_bb_requires_pop)
+#define BB_TEST_IS_SUCCESSOR(bb_test) (bb_test >> 1)
+#define BB_TEST_IS_REQUIRES_POP(bb_test) (bb_test & 1) 
+
 extern _Py_CODEUNIT *_PyCode_Tier2Warmup(struct _PyInterpreterFrame *,
     _Py_CODEUNIT *);
 extern _Py_CODEUNIT *_PyTier2_GenerateNextBB(
@@ -265,7 +279,7 @@ extern _Py_CODEUNIT *_PyTier2_GenerateNextBB(
     _Py_CODEUNIT *curr_executing_instr,
     int jumpby,
     _Py_CODEUNIT **tier1_fallback,
-    char gen_bb_is_successor);
+    char bb_flag);
 extern _Py_CODEUNIT *_PyTier2_LocateJumpBackwardsBB(
     struct _PyInterpreterFrame *frame, uint16_t bb_id, int jumpby,
     _Py_CODEUNIT **tier1_fallback);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1979,17 +1979,17 @@ dummy_func(
         inst(BB_TEST_POP_IF_TRUE, (cond -- )) {
             if (Py_IsFalse(cond)) {
                 _Py_DECREF_NO_DEALLOC(cond);
-                bb_test = BB_TEST(1, 0);;
+                bb_test = BB_TEST(1, 0);
             }
             else if (Py_IsTrue(cond)) {
                 _Py_DECREF_NO_DEALLOC(cond);
-                bb_test = BB_TEST(0, 0);;
+                bb_test = BB_TEST(0, 0);
             }
             else {
                 int err = PyObject_IsTrue(cond);
                 Py_DECREF(cond);
                 if (err > 0) {
-                    bb_test = BB_TEST(0, 0);;
+                    bb_test = BB_TEST(0, 0);
                 }
                 else {
                     ERROR_IF(err < 0, error);
@@ -2011,11 +2011,11 @@ dummy_func(
         inst(BB_TEST_POP_IF_NOT_NONE, (value -- )) {
             if (!Py_IsNone(value)) {
                 Py_DECREF(value);
-                bb_test = BB_TEST(0, 0);;
+                bb_test = BB_TEST(0, 0);
             }
             else {
                 _Py_DECREF_NO_DEALLOC(value);
-                bb_test = BB_TEST(1, 0);;
+                bb_test = BB_TEST(1, 0);
             }
         }
 
@@ -2026,6 +2026,17 @@ dummy_func(
             }
             else {
                 DECREF_INPUTS();
+            }
+        }
+
+        inst(BB_TEST_POP_IF_NONE, (value -- )) {
+            if (Py_IsNone(value)) {
+                Py_DECREF(value);
+                bb_test = BB_TEST(0, 0);
+            }
+            else {
+                _Py_DECREF_NO_DEALLOC(value);
+                bb_test = BB_TEST(1, 0);
             }
         }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -724,9 +724,8 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
     _PyCFrame cframe;
     _PyInterpreterFrame  entry_frame;
     PyObject *kwnames = NULL; // Borrowed reference. Reset by CALL instructions.
-    // true = successor
-    // false = alternate
-    char bb_test = true;
+
+    char bb_test = BB_TEST(0, 0);
 
     /* WARNING: Because the _PyCFrame lives on the C stack,
      * but can be accessed from a heap allocated object (tstate)

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2566,17 +2566,17 @@
             PyObject *cond = stack_pointer[-1];
             if (Py_IsFalse(cond)) {
                 _Py_DECREF_NO_DEALLOC(cond);
-                bb_test = BB_TEST(1, 0);;
+                bb_test = BB_TEST(1, 0);
             }
             else if (Py_IsTrue(cond)) {
                 _Py_DECREF_NO_DEALLOC(cond);
-                bb_test = BB_TEST(0, 0);;
+                bb_test = BB_TEST(0, 0);
             }
             else {
                 int err = PyObject_IsTrue(cond);
                 Py_DECREF(cond);
                 if (err > 0) {
-                    bb_test = BB_TEST(0, 0);;
+                    bb_test = BB_TEST(0, 0);
                 }
                 else {
                     if (err < 0) goto pop_1_error;
@@ -2603,11 +2603,11 @@
             PyObject *value = stack_pointer[-1];
             if (!Py_IsNone(value)) {
                 Py_DECREF(value);
-                bb_test = BB_TEST(0, 0);;
+                bb_test = BB_TEST(0, 0);
             }
             else {
                 _Py_DECREF_NO_DEALLOC(value);
-                bb_test = BB_TEST(1, 0);;
+                bb_test = BB_TEST(1, 0);
             }
             STACK_SHRINK(1);
             DISPATCH();
@@ -2621,6 +2621,20 @@
             }
             else {
                 Py_DECREF(value);
+            }
+            STACK_SHRINK(1);
+            DISPATCH();
+        }
+
+        TARGET(BB_TEST_POP_IF_NONE) {
+            PyObject *value = stack_pointer[-1];
+            if (Py_IsNone(value)) {
+                Py_DECREF(value);
+                bb_test = BB_TEST(0, 0);
+            }
+            else {
+                _Py_DECREF_NO_DEALLOC(value);
+                bb_test = BB_TEST(1, 0);
             }
             STACK_SHRINK(1);
             DISPATCH();

--- a/Python/opcode_metadata.h
+++ b/Python/opcode_metadata.h
@@ -279,6 +279,8 @@ _PyOpcode_num_popped(int opcode, int oparg, bool jump) {
             return 1;
         case POP_JUMP_IF_NONE:
             return 1;
+        case BB_TEST_POP_IF_NONE:
+            return 1;
         case JUMP_BACKWARD_NO_INTERRUPT:
             return 0;
         case GET_LEN:
@@ -673,6 +675,8 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
             return 0;
         case POP_JUMP_IF_NONE:
             return 0;
+        case BB_TEST_POP_IF_NONE:
+            return 0;
         case JUMP_BACKWARD_NO_INTERRUPT:
             return 0;
         case GET_LEN:
@@ -936,6 +940,7 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[256] = {
     [POP_JUMP_IF_NOT_NONE] = { true, INSTR_FMT_IB },
     [BB_TEST_POP_IF_NOT_NONE] = { true, INSTR_FMT_IX },
     [POP_JUMP_IF_NONE] = { true, INSTR_FMT_IB },
+    [BB_TEST_POP_IF_NONE] = { true, INSTR_FMT_IX },
     [JUMP_BACKWARD_NO_INTERRUPT] = { true, INSTR_FMT_IB },
     [GET_LEN] = { true, INSTR_FMT_IX },
     [MATCH_CLASS] = { true, INSTR_FMT_IB },

--- a/Python/tier2.c
+++ b/Python/tier2.c
@@ -77,6 +77,8 @@ _PyTier2TypeContext_Copy(const _PyTier2TypeContext *type_context)
 
 #if TYPEPROP_DEBUG
     fprintf(stderr, "  [*] Copying type context\n");
+    static void print_typestack(const _PyTier2TypeContext * type_context);
+    print_typestack(type_context);
 #endif
 
     _Py_TYPENODE_t *orig_type_locals = type_context->type_locals;
@@ -1962,10 +1964,10 @@ _PyTier2_RewriteForwardJump(_Py_CODEUNIT *bb_branch, _Py_CODEUNIT *target)
     assert(oparg <= 0xFFFF);
     if (requires_extended) {
         _py_set_opcode(write_curr, EXTENDED_ARG);
-        write_curr->op.arg = (oparg >> 8) & 0xFF;
-        write_curr++;
         // -1 to oparg because now the jump instruction moves one unit forward.
         oparg--;
+        write_curr->op.arg = (oparg >> 8) & 0xFF;
+        write_curr++;
     }
     _py_set_opcode(write_curr,
         branch == BB_BRANCH_IF_FLAG_SET ? BB_JUMP_IF_FLAG_SET : BB_JUMP_IF_FLAG_UNSET);

--- a/Python/tier2_typepropagator.c.h
+++ b/Python/tier2_typepropagator.c.h
@@ -790,14 +790,14 @@
         }
 
         TARGET(FOR_ITER) {
-            STACK_GROW(1);
-            TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(1), true);
+            fprintf(stderr, "Type propagation across `FOR_ITER` shouldn't be handled statically!\n");
+            Py_UNREACHABLE();
             break;
         }
 
         TARGET(BB_TEST_ITER) {
-            STACK_GROW(1);
-            TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(1), true);
+            fprintf(stderr, "Type propagation across `BB_TEST_ITER` shouldn't be handled statically!\n");
+            Py_UNREACHABLE();
             break;
         }
 

--- a/Python/tier2_typepropagator.c.h
+++ b/Python/tier2_typepropagator.c.h
@@ -745,6 +745,11 @@
             break;
         }
 
+        TARGET(BB_TEST_POP_IF_NONE) {
+            STACK_SHRINK(1);
+            break;
+        }
+
         TARGET(JUMP_BACKWARD_NO_INTERRUPT) {
             break;
         }

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -55,6 +55,8 @@ TYPE_PROPAGATOR_FORBIDDEN = [
     # Type propagator shouldn't see these
     "JUMP_IF_FALSE_OR_POP",
     "JUMP_IF_TRUE_OR_POP",
+    "BB_TEST_ITER",
+    "FOR_ITER",
     "SEND",
     "SEND_GEN",
     "YIELD_VALUE",


### PR DESCRIPTION
Applied previous fix for the now defunct `JUMP_IF_FALSE_OR_POP` and `JUMP_IF_TRUE_OR_POP` for `BB_TEST_ITER`.