### PR TITLE
Fix: Buggy type propagation across SWAP

### DIFF
--- a/Python/tier2.c
+++ b/Python/tier2.c
@@ -376,6 +376,74 @@ __type_propagate_TYPE_OVERWRITE(
     }
 }
 
+// src and dst are assumed to already be within the type context
+static void
+__type_propagate_TYPE_SWAP(
+    _PyTier2TypeContext *type_context,
+    _Py_TYPENODE_t *src, _Py_TYPENODE_t *dst)
+{
+    // Check if they are the same tree
+    _Py_TYPENODE_t *srcrootref = src;
+    _Py_TYPENODE_t *dstrootref = dst;
+    uintptr_t dsttag = _Py_TYPENODE_GET_TAG(*dst);
+    uintptr_t srctag = _Py_TYPENODE_GET_TAG(*src);
+    switch (dsttag) {
+    case TYPE_REF: dstrootref = __typenode_get_rootptr(*dst);
+    case TYPE_ROOT:
+        switch (srctag) {
+        case TYPE_REF: srcrootref = __typenode_get_rootptr(*src);
+        case TYPE_ROOT:
+            if (srcrootref == dstrootref) {
+                // Same tree, no point swapping
+                return;
+            }
+            break;
+        default:
+            Py_UNREACHABLE();
+        }
+        break;
+    default:
+        Py_UNREACHABLE();
+    }
+
+    // src and dst are different tree,
+    // Make all children of src be children of dst and vice versa
+
+    _Py_TYPENODE_t src_child_test = _Py_TYPENODE_MAKE_REF(
+        _Py_TYPENODE_CLEAR_TAG((_Py_TYPENODE_t)src));
+    _Py_TYPENODE_t dst_child_test = _Py_TYPENODE_MAKE_REF(
+        _Py_TYPENODE_CLEAR_TAG((_Py_TYPENODE_t)dst));
+
+    // Search locals for children
+    int nlocals = type_context->type_locals_len;
+    for (int i = 0; i < nlocals; i++) {
+        _Py_TYPENODE_t *node_ptr = &(type_context->type_locals[i]);
+        if (*node_ptr == src_child_test) {
+            *node_ptr = dst;
+        }
+        else if (*node_ptr == dst_child_test) {
+            *node_ptr = src;
+        }
+    }
+
+    // Search stack for children
+    int nstack = type_context->type_stack_len;
+    for (int i = 0; i < nstack; i++) {
+        _Py_TYPENODE_t *node_ptr = &(type_context->type_stack[i]);
+        if (*node_ptr == src_child_test) {
+            *node_ptr = dst;
+        }
+        else if (*node_ptr == dst_child_test) {
+            *node_ptr = src;
+        }
+    }
+
+    // Finally, actually swap the nodes
+    *src ^= *dst;
+    *dst ^= *src;
+    *src ^= *dst;
+}
+
 static void
 __type_stack_shrink(_Py_TYPENODE_t **type_stackptr, int idx)
 {
@@ -489,6 +557,7 @@ type_propagate(
 
 #define TYPE_SET(src, dst, flag)        __type_propagate_TYPE_SET((src), (dst), (flag))
 #define TYPE_OVERWRITE(src, dst, flag)  __type_propagate_TYPE_OVERWRITE(type_context, (src), (dst), (flag))
+#define TYPE_SWAP(src, dst)             __type_propagate_TYPE_SWAP(type_context, (src), (dst))
 
 #define STACK_GROW(idx)             *type_stackptr += (idx)
 
@@ -504,8 +573,18 @@ type_propagate(
 
     switch (opcode) {
 #include "tier2_typepropagator.c.h"
+    TARGET(SWAP) {
+        _Py_TYPENODE_t *top = TYPESTACK_PEEK(1);
+        _Py_TYPENODE_t * bottom = TYPESTACK_PEEK(2 + (oparg - 2));
+        TYPE_SWAP(top, bottom);
+        break;
+    }
     default:
+#ifdef Py_DEBUG
+        fprintf(stderr, "Unsupported opcode in type propagator: %s : %d\n", _PyOpcode_OpName[opcode], oparg);
+#else
         fprintf(stderr, "Unsupported opcode in type propagator: %d\n", opcode);
+#endif
         Py_UNREACHABLE();
     }
 

--- a/Python/tier2.c
+++ b/Python/tier2.c
@@ -419,10 +419,10 @@ __type_propagate_TYPE_SWAP(
     for (int i = 0; i < nlocals; i++) {
         _Py_TYPENODE_t *node_ptr = &(type_context->type_locals[i]);
         if (*node_ptr == src_child_test) {
-            *node_ptr = dst;
+            *node_ptr = dst_child_test;
         }
         else if (*node_ptr == dst_child_test) {
-            *node_ptr = src;
+            *node_ptr = src_child_test;
         }
     }
 
@@ -431,10 +431,10 @@ __type_propagate_TYPE_SWAP(
     for (int i = 0; i < nstack; i++) {
         _Py_TYPENODE_t *node_ptr = &(type_context->type_stack[i]);
         if (*node_ptr == src_child_test) {
-            *node_ptr = dst;
+            *node_ptr = dst_child_test;
         }
         else if (*node_ptr == dst_child_test) {
-            *node_ptr = src;
+            *node_ptr = src_child_test;
         }
     }
 

--- a/Python/tier2_typepropagator.c.h
+++ b/Python/tier2_typepropagator.c.h
@@ -284,12 +284,6 @@
             break;
         }
 
-        TARGET(RAISE_VARARGS) {
-            fprintf(stderr, "Type propagation across `RAISE_VARARGS` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
         TARGET(INTERPRETER_EXIT) {
             STACK_SHRINK(1);
             break;
@@ -317,36 +311,6 @@
 
         TARGET(GET_AWAITABLE) {
             TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(1), true);
-            break;
-        }
-
-        TARGET(SEND) {
-            fprintf(stderr, "Type propagation across `SEND` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
-        TARGET(SEND_GEN) {
-            fprintf(stderr, "Type propagation across `SEND_GEN` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
-        TARGET(YIELD_VALUE) {
-            fprintf(stderr, "Type propagation across `YIELD_VALUE` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
-        TARGET(POP_EXCEPT) {
-            fprintf(stderr, "Type propagation across `POP_EXCEPT` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
-        TARGET(RERAISE) {
-            fprintf(stderr, "Type propagation across `RERAISE` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
             break;
         }
 
@@ -464,18 +428,6 @@
             break;
         }
 
-        TARGET(DELETE_FAST) {
-            fprintf(stderr, "Type propagation across `DELETE_FAST` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
-        TARGET(MAKE_CELL) {
-            fprintf(stderr, "Type propagation across `MAKE_CELL` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
         TARGET(DELETE_DEREF) {
             break;
         }
@@ -483,12 +435,6 @@
         TARGET(LOAD_CLASSDEREF) {
             STACK_GROW(1);
             TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(1), true);
-            break;
-        }
-
-        TARGET(LOAD_DEREF) {
-            fprintf(stderr, "Type propagation across `LOAD_DEREF` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
             break;
         }
 
@@ -766,24 +712,6 @@
             break;
         }
 
-        TARGET(MATCH_MAPPING) {
-            fprintf(stderr, "Type propagation across `MATCH_MAPPING` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
-        TARGET(MATCH_SEQUENCE) {
-            fprintf(stderr, "Type propagation across `MATCH_SEQUENCE` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
-        TARGET(MATCH_KEYS) {
-            fprintf(stderr, "Type propagation across `MATCH_KEYS` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
         TARGET(GET_ITER) {
             TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(1), true);
             break;
@@ -791,12 +719,6 @@
 
         TARGET(GET_YIELD_FROM_ITER) {
             TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(1), true);
-            break;
-        }
-
-        TARGET(FOR_ITER) {
-            fprintf(stderr, "Type propagation across `FOR_ITER` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
             break;
         }
 
@@ -840,18 +762,6 @@
             STACK_GROW(1);
             TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(1), true);
             TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(2), true);
-            break;
-        }
-
-        TARGET(WITH_EXCEPT_START) {
-            fprintf(stderr, "Type propagation across `WITH_EXCEPT_START` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
-            break;
-        }
-
-        TARGET(PUSH_EXC_INFO) {
-            fprintf(stderr, "Type propagation across `PUSH_EXC_INFO` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
             break;
         }
 
@@ -1042,20 +952,6 @@
         TARGET(BINARY_OP) {
             STACK_SHRINK(1);
             TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK(1), true);
-            break;
-        }
-
-        TARGET(SWAP) {
-            _Py_TYPENODE_t *top = TYPESTACK_PEEK(1);
-            _Py_TYPENODE_t *bottom = TYPESTACK_PEEK(2 + (oparg-2));
-            TYPE_OVERWRITE(bottom, TYPESTACK_PEEK(1), false);
-            TYPE_OVERWRITE(top, TYPESTACK_PEEK(2 + (oparg-2)), false);
-            break;
-        }
-
-        TARGET(EXTENDED_ARG) {
-            fprintf(stderr, "Type propagation across `EXTENDED_ARG` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
             break;
         }
 

--- a/Python/tier2_typepropagator.c.h
+++ b/Python/tier2_typepropagator.c.h
@@ -1054,8 +1054,6 @@
         }
 
         TARGET(EXTENDED_ARG) {
-            fprintf(stderr, "Type propagation across `EXTENDED_ARG` shouldn't be handled statically!\n");
-            Py_UNREACHABLE();
             break;
         }
 

--- a/Python/tier2_typepropagator.c.h
+++ b/Python/tier2_typepropagator.c.h
@@ -1054,6 +1054,8 @@
         }
 
         TARGET(EXTENDED_ARG) {
+            fprintf(stderr, "Type propagation across `EXTENDED_ARG` shouldn't be handled statically!\n");
+            Py_UNREACHABLE();
             break;
         }
 

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -70,7 +70,6 @@ TYPE_PROPAGATOR_FORBIDDEN = [
     "MATCH_MAPPING",
     "MATCH_SEQUENCE",
     "MATCH_KEYS",
-    "EXTENDED_ARG",
     "WITH_EXCEPT_START",
     # Type propagation across these instructions are forbidden
     # due to conditional effects that can't be determined statically

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -70,6 +70,7 @@ TYPE_PROPAGATOR_FORBIDDEN = [
     "MATCH_MAPPING",
     "MATCH_SEQUENCE",
     "MATCH_KEYS",
+    "EXTENDED_ARG",
     "WITH_EXCEPT_START",
     # Type propagation across these instructions are forbidden
     # due to conditional effects that can't be determined statically


### PR DESCRIPTION
The fix involves separating SWAP out of the DSL and is handled specially in the type prop switch case.
Also there's a new type prop operation "TYPE_SWAP"