### PR TITLE
Minor Changes

### DIFF
--- a/Include/internal/pycore_opcode_metadata.h
+++ b/Include/internal/pycore_opcode_metadata.h
@@ -2417,8 +2417,6 @@ bool _PyOpcode_isguard(uint32_t opcode)  {
         case _GUARD_KEYS_VERSION:
         case _CHECK_CALL_BOUND_METHOD_EXACT_ARGS:
         case _CHECK_PEP_523:
-        case _CHECK_FUNCTION_EXACT_ARGS:
-        case _CHECK_STACK_SPACE:
             return true;
         default:
             return false;

--- a/Include/internal/pycore_opcode_metadata.h
+++ b/Include/internal/pycore_opcode_metadata.h
@@ -92,7 +92,8 @@
 #define _LOAD_FAST_NO_INCREF 363
 #define _LOAD_CONST_IMMEDIATE 364
 #define _SHRINK_STACK 365
-#define _INSERT 366
+#define _SWAP_AND_POP 366
+#define _INSERT 367
 
 extern int _PyOpcode_num_popped(int opcode, int oparg, bool jump);
 #ifdef NEED_OPCODE_METADATA
@@ -670,6 +671,8 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 0;
         case _SHRINK_STACK:
             return oparg;
+        case _SWAP_AND_POP:
+            return oparg + 1;
         case _INSERT:
             return oparg + 1;
         default:
@@ -1254,6 +1257,8 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 1;
         case _SHRINK_STACK:
             return 0;
+        case _SWAP_AND_POP:
+            return oparg;
         case _INSERT:
             return oparg + 1;
         default:
@@ -1615,6 +1620,7 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [_LOAD_FAST_NO_INCREF] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_LOCAL_FLAG },
     [_LOAD_CONST_IMMEDIATE] = { true, INSTR_FMT_IXC000, 0 },
     [_SHRINK_STACK] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
+    [_SWAP_AND_POP] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
     [_INSERT] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
 };
 #endif // NEED_OPCODE_METADATA
@@ -1840,6 +1846,7 @@ const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE] = {
     [_LOAD_FAST_NO_INCREF] = "_LOAD_FAST_NO_INCREF",
     [_LOAD_CONST_IMMEDIATE] = "_LOAD_CONST_IMMEDIATE",
     [_SHRINK_STACK] = "_SHRINK_STACK",
+    [_SWAP_AND_POP] = "_SWAP_AND_POP",
     [_INSERT] = "_INSERT",
 };
 #endif // NEED_OPCODE_METADATA
@@ -2386,6 +2393,7 @@ bool _PyOpcode_ispure(uint32_t opcode)  {
         case _LOAD_FAST_NO_INCREF:
         case _LOAD_CONST_IMMEDIATE:
         case _SHRINK_STACK:
+        case _SWAP_AND_POP:
             return true;
         default:
             return false;

--- a/Python/abstract_interp_cases.c.h
+++ b/Python/abstract_interp_cases.c.h
@@ -53,18 +53,18 @@
         }
 
         case UNARY_NOT: {
-            _Py_UOpsSymbolicExpression *__value;
-            __value = stack_pointer[-1];
+            _Py_UOpsSymbolicExpression *___value;
+            ___value = stack_pointer[-1];
             _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (is_const(__value)) {
-                PyObject *value = get_const(__value);
+            if (is_const(___value)) {
+                PyObject *value = get_const(___value);
                 PyObject *res;
                 assert(PyBool_Check(value));
                 res = Py_IsFalse(value) ? Py_True : Py_False;
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 1 , __value);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 1 , ___value);
             }
             else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 1 , __value);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 1 , ___value);
             }
             if (__sym_temp == NULL) goto error;
             PEEK(-(-1)) = __sym_temp;
@@ -112,13 +112,13 @@
         }
 
         case _GUARD_BOTH_INT: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 DEOPT_IF(!PyLong_CheckExact(left), _GUARD_BOTH_INT);
                 DEOPT_IF(!PyLong_CheckExact(right), _GUARD_BOTH_INT);
                 DPRINTF(2, "const eliminated guard\n");
@@ -141,25 +141,25 @@
         }
 
         case _BINARY_OP_MULTIPLY_INT: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
             STACK_SHRINK(1);
             _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 res = _PyLong_Multiply((PyLongObject *)left, (PyLongObject *)right);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , ___left, ___right);
             }
             else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , ___left, ___right);
             }
             if (__sym_temp == NULL) goto error;
             sym_set_type(__sym_temp, PYINT_TYPE, (uint32_t)0);
@@ -168,25 +168,25 @@
         }
 
         case _BINARY_OP_ADD_INT: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
             STACK_SHRINK(1);
             _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 res = _PyLong_Add((PyLongObject *)left, (PyLongObject *)right);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , ___left, ___right);
             }
             else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , ___left, ___right);
             }
             if (__sym_temp == NULL) goto error;
             sym_set_type(__sym_temp, PYINT_TYPE, (uint32_t)0);
@@ -195,25 +195,25 @@
         }
 
         case _BINARY_OP_SUBTRACT_INT: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
             STACK_SHRINK(1);
             _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 res = _PyLong_Subtract((PyLongObject *)left, (PyLongObject *)right);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , ___left, ___right);
             }
             else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , ___left, ___right);
             }
             if (__sym_temp == NULL) goto error;
             sym_set_type(__sym_temp, PYINT_TYPE, (uint32_t)0);
@@ -222,13 +222,13 @@
         }
 
         case _GUARD_BOTH_FLOAT: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 DEOPT_IF(!PyFloat_CheckExact(left), _GUARD_BOTH_FLOAT);
                 DEOPT_IF(!PyFloat_CheckExact(right), _GUARD_BOTH_FLOAT);
                 DPRINTF(2, "const eliminated guard\n");
@@ -251,25 +251,25 @@
         }
 
         case _BINARY_OP_MULTIPLY_FLOAT: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
             STACK_SHRINK(1);
             _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 double dres =
                     ((PyFloatObject *)left)->ob_fval *
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , ___left, ___right);
             }
             else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , ___left, ___right);
             }
             if (__sym_temp == NULL) goto error;
             sym_set_type(__sym_temp, PYFLOAT_TYPE, (uint32_t)0);
@@ -278,25 +278,25 @@
         }
 
         case _BINARY_OP_ADD_FLOAT: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
             STACK_SHRINK(1);
             _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 double dres =
                     ((PyFloatObject *)left)->ob_fval +
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , ___left, ___right);
             }
             else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , ___left, ___right);
             }
             if (__sym_temp == NULL) goto error;
             sym_set_type(__sym_temp, PYFLOAT_TYPE, (uint32_t)0);
@@ -305,25 +305,25 @@
         }
 
         case _BINARY_OP_SUBTRACT_FLOAT: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
             STACK_SHRINK(1);
             _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 double dres =
                     ((PyFloatObject *)left)->ob_fval -
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , ___left, ___right);
             }
             else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , ___left, ___right);
             }
             if (__sym_temp == NULL) goto error;
             sym_set_type(__sym_temp, PYFLOAT_TYPE, (uint32_t)0);
@@ -332,13 +332,13 @@
         }
 
         case _GUARD_BOTH_UNICODE: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 DEOPT_IF(!PyUnicode_CheckExact(left), _GUARD_BOTH_UNICODE);
                 DEOPT_IF(!PyUnicode_CheckExact(right), _GUARD_BOTH_UNICODE);
                 DPRINTF(2, "const eliminated guard\n");
@@ -361,25 +361,25 @@
         }
 
         case _BINARY_OP_ADD_UNICODE: {
-            _Py_UOpsSymbolicExpression *__left;
-            _Py_UOpsSymbolicExpression *__right;
-            __right = stack_pointer[-1];
-            __left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *___left;
+            _Py_UOpsSymbolicExpression *___right;
+            ___right = stack_pointer[-1];
+            ___left = stack_pointer[-2];
             STACK_SHRINK(1);
             _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (is_const(__left) && is_const(__right)) {
-                PyObject *left = get_const(__left);
-                PyObject *right = get_const(__right);
+            if (is_const(___left) && is_const(___right)) {
+                PyObject *left = get_const(___left);
+                PyObject *right = get_const(___right);
                 PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 res = PyUnicode_Concat(left, right);
                 _Py_DECREF_SPECIALIZED(left, _PyUnicode_ExactDealloc);
                 _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
                 if (res == NULL) goto pop_2_error;
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)res, 2 , ___left, ___right);
             }
             else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , __left, __right);
+                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 2 , ___left, ___right);
             }
             if (__sym_temp == NULL) goto error;
             PEEK(-(-1)) = __sym_temp;
@@ -438,6 +438,18 @@
             break;
         }
 
+        case LIST_APPEND: {
+            STACK_SHRINK(1);
+            PEEK(-(-1 - (oparg-1))) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case SET_ADD: {
+            STACK_SHRINK(1);
+            PEEK(-(-1 - (oparg-1))) = sym_init_unknown(ctx);
+            break;
+        }
+
         case STORE_SUBSCR: {
             STACK_SHRINK(3);
             break;
@@ -466,6 +478,11 @@
         case CALL_INTRINSIC_2: {
             STACK_SHRINK(1);
             PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case RAISE_VARARGS: {
+            STACK_SHRINK(oparg);
             break;
         }
 
@@ -528,6 +545,11 @@
         }
 
         case POP_EXCEPT: {
+            STACK_SHRINK(1);
+            break;
+        }
+
+        case RERAISE: {
             STACK_SHRINK(1);
             break;
         }
@@ -697,7 +719,81 @@
             break;
         }
 
+        case BUILD_STRING: {
+            STACK_SHRINK(oparg);
+            STACK_GROW(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case BUILD_TUPLE: {
+            STACK_SHRINK(oparg);
+            STACK_GROW(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case BUILD_LIST: {
+            STACK_SHRINK(oparg);
+            STACK_GROW(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case LIST_EXTEND: {
+            STACK_SHRINK(1);
+            PEEK(-(-1 - (oparg-1))) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case SET_UPDATE: {
+            STACK_SHRINK(1);
+            PEEK(-(-1 - (oparg-1))) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case BUILD_SET: {
+            STACK_SHRINK(oparg);
+            STACK_GROW(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case BUILD_MAP: {
+            STACK_SHRINK(oparg*2);
+            STACK_GROW(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
         case SETUP_ANNOTATIONS: {
+            break;
+        }
+
+        case BUILD_CONST_KEY_MAP: {
+            STACK_SHRINK(oparg);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case DICT_UPDATE: {
+            STACK_SHRINK(1);
+            PEEK(-(-1 - (oparg - 1))) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case DICT_MERGE: {
+            STACK_SHRINK(1);
+            PEEK(-(-4 - (oparg - 1))) = sym_init_unknown(ctx);
+            PEEK(-(-3 - (oparg - 1))) = sym_init_unknown(ctx);
+            PEEK(-(-2 - (oparg - 1))) = sym_init_unknown(ctx);
+            PEEK(-(-1 - (oparg - 1))) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case MAP_ADD: {
+            STACK_SHRINK(2);
+            PEEK(-(-1 - (oparg - 1))) = sym_init_unknown(ctx);
             break;
         }
 
@@ -739,10 +835,10 @@
         }
 
         case _GUARD_TYPE_VERSION: {
-            _Py_UOpsSymbolicExpression *__owner;
-            __owner = stack_pointer[-1];
-            if (is_const(__owner)) {
-                PyObject *owner = get_const(__owner);
+            _Py_UOpsSymbolicExpression *___owner;
+            ___owner = stack_pointer[-1];
+            if (is_const(___owner)) {
+                PyObject *owner = get_const(___owner);
                 uint32_t type_version = (uint32_t)operand;
                 PyTypeObject *tp = Py_TYPE(owner);
                 assert(type_version != 0);
@@ -833,10 +929,10 @@
         }
 
         case _GUARD_DORV_VALUES: {
-            _Py_UOpsSymbolicExpression *__owner;
-            __owner = stack_pointer[-1];
-            if (is_const(__owner)) {
-                PyObject *owner = get_const(__owner);
+            _Py_UOpsSymbolicExpression *___owner;
+            ___owner = stack_pointer[-1];
+            if (is_const(___owner)) {
+                PyObject *owner = get_const(___owner);
                 assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
                 PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
                 DEOPT_IF(!_PyDictOrValues_IsValues(dorv), _GUARD_DORV_VALUES);
@@ -1131,10 +1227,10 @@
         }
 
         case _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT: {
-            _Py_UOpsSymbolicExpression *__owner;
-            __owner = stack_pointer[-1];
-            if (is_const(__owner)) {
-                PyObject *owner = get_const(__owner);
+            _Py_UOpsSymbolicExpression *___owner;
+            ___owner = stack_pointer[-1];
+            if (is_const(___owner)) {
+                PyObject *owner = get_const(___owner);
                 assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
                 PyDictOrValues *dorv = _PyObject_DictOrValuesPointer(owner);
                 DEOPT_IF(!_PyDictOrValues_IsValues(*dorv) && !_PyObject_MakeInstanceAttributesFromDict(owner, dorv), _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT);
@@ -1156,10 +1252,10 @@
         }
 
         case _GUARD_KEYS_VERSION: {
-            _Py_UOpsSymbolicExpression *__owner;
-            __owner = stack_pointer[-1];
-            if (is_const(__owner)) {
-                PyObject *owner = get_const(__owner);
+            _Py_UOpsSymbolicExpression *___owner;
+            ___owner = stack_pointer[-1];
+            if (is_const(___owner)) {
+                PyObject *owner = get_const(___owner);
                 uint32_t keys_version = (uint32_t)operand;
                 PyTypeObject *owner_cls = Py_TYPE(owner);
                 PyHeapTypeObject *owner_heap_type = (PyHeapTypeObject *)owner_cls;
@@ -1224,12 +1320,108 @@
             break;
         }
 
+        case CALL: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case _CHECK_CALL_BOUND_METHOD_EXACT_ARGS: {
+            _Py_UOpsSymbolicExpression *___callable;
+            _Py_UOpsSymbolicExpression *___null;
+            ___null = stack_pointer[-1 - oparg];
+            ___callable = stack_pointer[-2 - oparg];
+            if (is_const(___callable) && is_const(___null)) {
+                PyObject *callable = get_const(___callable);
+                PyObject *null = get_const(___null);
+                DEOPT_IF(null != NULL, _CHECK_CALL_BOUND_METHOD_EXACT_ARGS);
+                DEOPT_IF(Py_TYPE(callable) != &PyMethod_Type, _CHECK_CALL_BOUND_METHOD_EXACT_ARGS);
+                DPRINTF(2, "const eliminated guard\n");
+                break;
+            }
+            _Py_UOpsSymbolicExpression *null = (_Py_UOpsSymbolicExpression *)stack_pointer[-1 - oparg];
+            _Py_UOpsSymbolicExpression *callable = (_Py_UOpsSymbolicExpression *)stack_pointer[-2 - oparg];
+            if (should_type_propagate) {
+                sym_set_type((_Py_UOpsSymbolicExpression *)callable, PYMETHOD_TYPE, (uint32_t)0);;
+                sym_set_type((_Py_UOpsSymbolicExpression *)null, PYNULL_TYPE, (uint32_t)0);;
+            }
+            else {
+                if (sym_matches_type((_Py_UOpsSymbolicExpression *)callable, PYMETHOD_TYPE, (uint32_t)0) && sym_matches_type((_Py_UOpsSymbolicExpression *)null, PYNULL_TYPE, (uint32_t)0)) {
+                    DPRINTF(2, "type propagation eliminated guard\n");
+                    break;
+                }
+                goto guard_required;
+            }
+            break;
+        }
+
+        case _INIT_CALL_BOUND_METHOD_EXACT_ARGS: {
+            PEEK(-(-2 - oparg)) = sym_init_unknown(ctx);
+            PEEK(-(-1 - oparg)) = sym_init_unknown(ctx);
+            break;
+        }
+
         case _CHECK_PEP_523: {
             goto guard_required;
             break;
         }
 
+        case _CHECK_FUNCTION_EXACT_ARGS: {
+            PEEK(-(-2 - oparg)) = sym_init_unknown(ctx);
+            PEEK(-(-1 - oparg)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case _CHECK_STACK_SPACE: {
+            PEEK(-(-2 - oparg)) = sym_init_unknown(ctx);
+            PEEK(-(-1 - oparg)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case _INIT_CALL_PY_EXACT_ARGS: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
         case _PUSH_FRAME: {
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_PY_WITH_DEFAULTS: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_TYPE_1: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_STR_1: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_TUPLE_1: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_ALLOC_AND_ENTER_INIT: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
             PEEK(-(-1)) = sym_init_unknown(ctx);
             break;
         }
@@ -1239,7 +1431,91 @@
             break;
         }
 
+        case CALL_BUILTIN_CLASS: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_BUILTIN_O: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_BUILTIN_FAST: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_BUILTIN_FAST_WITH_KEYWORDS: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_LEN: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_ISINSTANCE: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_LIST_APPEND: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_METHOD_DESCRIPTOR_O: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_METHOD_DESCRIPTOR_NOARGS: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
+        case CALL_METHOD_DESCRIPTOR_FAST: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
+            break;
+        }
+
         case INSTRUMENTED_CALL_KW: {
+            break;
+        }
+
+        case CALL_KW: {
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(2);
+            PEEK(-(-1)) = sym_init_unknown(ctx);
             break;
         }
 
@@ -1361,5 +1637,15 @@
         }
 
         case _EXIT_TRACE: {
+            break;
+        }
+
+        case _SHRINK_STACK: {
+            STACK_SHRINK(oparg);
+            break;
+        }
+
+        case _INSERT: {
+            PEEK(-(-1 - oparg)) = sym_init_unknown(ctx);
             break;
         }

--- a/Python/abstract_interp_cases.c.h
+++ b/Python/abstract_interp_cases.c.h
@@ -124,8 +124,8 @@
                 DPRINTF(2, "const eliminated guard\n");
                 break;
             }
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *right = (_Py_UOpsSymbolicExpression *)stack_pointer[-1];
+            _Py_UOpsSymbolicExpression *left = (_Py_UOpsSymbolicExpression *)stack_pointer[-2];
             if (should_type_propagate) {
                 sym_set_type((_Py_UOpsSymbolicExpression *)left, PYINT_TYPE, (uint32_t)0);;
                 sym_set_type((_Py_UOpsSymbolicExpression *)right, PYINT_TYPE, (uint32_t)0);;
@@ -234,8 +234,8 @@
                 DPRINTF(2, "const eliminated guard\n");
                 break;
             }
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *right = (_Py_UOpsSymbolicExpression *)stack_pointer[-1];
+            _Py_UOpsSymbolicExpression *left = (_Py_UOpsSymbolicExpression *)stack_pointer[-2];
             if (should_type_propagate) {
                 sym_set_type((_Py_UOpsSymbolicExpression *)left, PYFLOAT_TYPE, (uint32_t)0);;
                 sym_set_type((_Py_UOpsSymbolicExpression *)right, PYFLOAT_TYPE, (uint32_t)0);;
@@ -344,8 +344,8 @@
                 DPRINTF(2, "const eliminated guard\n");
                 break;
             }
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            _Py_UOpsSymbolicExpression *right = (_Py_UOpsSymbolicExpression *)stack_pointer[-1];
+            _Py_UOpsSymbolicExpression *left = (_Py_UOpsSymbolicExpression *)stack_pointer[-2];
             if (should_type_propagate) {
                 sym_set_type((_Py_UOpsSymbolicExpression *)left, PYUNICODE_TYPE, (uint32_t)0);;
                 sym_set_type((_Py_UOpsSymbolicExpression *)right, PYUNICODE_TYPE, (uint32_t)0);;
@@ -751,7 +751,7 @@
                 break;
             }
             uint32_t type_version = (uint32_t)operand;
-            PyObject *owner = stack_pointer[-1];
+            _Py_UOpsSymbolicExpression *owner = (_Py_UOpsSymbolicExpression *)stack_pointer[-1];
             if (should_type_propagate) {
                 sym_set_type((_Py_UOpsSymbolicExpression *)owner, GUARD_TYPE_VERSION_TYPE, (uint32_t)type_version);;
             }
@@ -843,7 +843,7 @@
                 DPRINTF(2, "const eliminated guard\n");
                 break;
             }
-            PyObject *owner = stack_pointer[-1];
+            _Py_UOpsSymbolicExpression *owner = (_Py_UOpsSymbolicExpression *)stack_pointer[-1];
             if (should_type_propagate) {
                 sym_set_type((_Py_UOpsSymbolicExpression *)owner, GUARD_DORV_VALUES_TYPE, (uint32_t)0);;
             }
@@ -1141,7 +1141,7 @@
                 DPRINTF(2, "const eliminated guard\n");
                 break;
             }
-            PyObject *owner = stack_pointer[-1];
+            _Py_UOpsSymbolicExpression *owner = (_Py_UOpsSymbolicExpression *)stack_pointer[-1];
             if (should_type_propagate) {
                 sym_set_type((_Py_UOpsSymbolicExpression *)owner, GUARD_DORV_VALUES_INST_ATTR_FROM_DICT_TYPE, (uint32_t)0);;
             }
@@ -1168,7 +1168,7 @@
                 break;
             }
             uint32_t keys_version = (uint32_t)operand;
-            PyObject *owner = stack_pointer[-1];
+            _Py_UOpsSymbolicExpression *owner = (_Py_UOpsSymbolicExpression *)stack_pointer[-1];
             if (should_type_propagate) {
                 sym_set_type((_Py_UOpsSymbolicExpression *)owner, GUARD_KEYS_VERSION_TYPE, (uint32_t)keys_version);;
             }
@@ -1361,40 +1361,5 @@
         }
 
         case _EXIT_TRACE: {
-            break;
-        }
-
-        case _LOAD_FAST_NO_INCREF: {
-            STACK_GROW(1);
-            _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (0) {
-                PyObject *value;
-                value = GETLOCAL(oparg);
-                assert(value != NULL);
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)value, 0 );
-            }
-            else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 0 );
-            }
-            if (__sym_temp == NULL) goto error;
-            PEEK(-(-1)) = __sym_temp;
-            break;
-        }
-
-        case _LOAD_CONST_IMMEDIATE: {
-            STACK_GROW(1);
-            _Py_UOpsSymbolicExpression *__sym_temp = NULL;
-            if (0) {
-                PyObject *value;
-                PyObject *op = (PyObject *)operand;
-                value = op;
-                Py_INCREF(value);
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, (PyObject *)value, 0 );
-            }
-            else {
-                __sym_temp = _Py_UOpsSymbolicExpression_New(ctx, opcode, oparg, NULL, 0 );
-            }
-            if (__sym_temp == NULL) goto error;
-            PEEK(-(-1)) = __sym_temp;
             break;
         }

--- a/Python/abstract_interp_cases.c.h
+++ b/Python/abstract_interp_cases.c.h
@@ -1344,10 +1344,10 @@
             _Py_UOpsSymbolicExpression *callable = (_Py_UOpsSymbolicExpression *)stack_pointer[-2 - oparg];
             if (should_type_propagate) {
                 sym_set_type((_Py_UOpsSymbolicExpression *)callable, PYMETHOD_TYPE, (uint32_t)0);;
-                sym_set_type((_Py_UOpsSymbolicExpression *)null, PYNULL_TYPE, (uint32_t)0);;
+                sym_set_type((_Py_UOpsSymbolicExpression *)null, NULL_TYPE, (uint32_t)0);;
             }
             else {
-                if (sym_matches_type((_Py_UOpsSymbolicExpression *)callable, PYMETHOD_TYPE, (uint32_t)0) && sym_matches_type((_Py_UOpsSymbolicExpression *)null, PYNULL_TYPE, (uint32_t)0)) {
+                if (sym_matches_type((_Py_UOpsSymbolicExpression *)callable, PYMETHOD_TYPE, (uint32_t)0) && sym_matches_type((_Py_UOpsSymbolicExpression *)null, NULL_TYPE, (uint32_t)0)) {
                     DPRINTF(2, "type propagation eliminated guard\n");
                     break;
                 }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3024,7 +3024,7 @@ dummy_func(
             CHECK_EVAL_BREAKER();
         }
 
-        guard op(_CHECK_CALL_BOUND_METHOD_EXACT_ARGS, (callable, null, unused[oparg] -- callable, null, unused[oparg])) {
+        guard op(_CHECK_CALL_BOUND_METHOD_EXACT_ARGS, (callable: ~(PYMETHOD_TYPE), null: ~(PYNULL_TYPE), unused[oparg] -- callable, null, unused[oparg])) {
             DEOPT_IF(null != NULL);
             DEOPT_IF(Py_TYPE(callable) != &PyMethod_Type);
         }
@@ -3042,7 +3042,7 @@ dummy_func(
             DEOPT_IF(tstate->interp->eval_frame);
         }
 
-        guard op(_CHECK_FUNCTION_EXACT_ARGS, (func_version/2, callable, self_or_null, unused[oparg] -- callable, self_or_null, unused[oparg])) {
+        op(_CHECK_FUNCTION_EXACT_ARGS, (func_version/2, callable, self_or_null, unused[oparg] -- callable, self_or_null, unused[oparg])) {
             DEOPT_IF(!PyFunction_Check(callable));
             PyFunctionObject *func = (PyFunctionObject *)callable;
             DEOPT_IF(func->func_version != func_version);
@@ -3050,7 +3050,7 @@ dummy_func(
             DEOPT_IF(code->co_argcount != oparg + (self_or_null != NULL));
         }
 
-        guard op(_CHECK_STACK_SPACE, (callable, unused, unused[oparg] -- callable, unused, unused[oparg])) {
+        op(_CHECK_STACK_SPACE, (callable, unused, unused[oparg] -- callable, unused, unused[oparg])) {
             PyFunctionObject *func = (PyFunctionObject *)callable;
             PyCodeObject *code = (PyCodeObject *)func->func_code;
             DEOPT_IF(!_PyThreadState_HasStackSpace(tstate, code->co_framesize));

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3024,7 +3024,7 @@ dummy_func(
             CHECK_EVAL_BREAKER();
         }
 
-        guard op(_CHECK_CALL_BOUND_METHOD_EXACT_ARGS, (callable: ~(PYMETHOD_TYPE), null: ~(PYNULL_TYPE), unused[oparg] -- callable, null, unused[oparg])) {
+        guard op(_CHECK_CALL_BOUND_METHOD_EXACT_ARGS, (callable: ~(PYMETHOD_TYPE), null: ~(NULL_TYPE), unused[oparg] -- callable, null, unused[oparg])) {
             DEOPT_IF(null != NULL);
             DEOPT_IF(Py_TYPE(callable) != &PyMethod_Type);
         }

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3308,6 +3308,17 @@
             break;
         }
 
+        case _SWAP_AND_POP: {
+            PyObject *tos;
+            PyObject **target;
+            tos = stack_pointer[-1];
+            target = stack_pointer - 1 - oparg;
+            Py_DECREF(*target);
+            *target = tos;
+            STACK_SHRINK(1);
+            break;
+        }
+
         case _INSERT: {
             PyObject *top;
             top = stack_pointer[-1];

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -987,6 +987,18 @@ uop_abstract_interpret_single_inst(
             break;
         }
 
+        case PUSH_NULL: {
+            STACK_GROW(1);
+            PEEK(1) = _Py_UOpsSymbolicExpression_New(
+                ctx,
+                PUSH_NULL,
+                0,
+                NULL,
+                0
+            );
+            break;
+        }
+
         // TODO SWAP
         default:
             DPRINTF(1, "Unknown opcode in abstract interpreter\n");

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -1021,7 +1021,7 @@ uop_abstract_interpret_single_inst(
 
         case PUSH_NULL: {
             STACK_GROW(1);
-            _Py_UOpsSymbolicExpression *null_sym =  _Py_UOpsSymbolicExpression_NewSingleton(PUSH_NULL, 0);
+            _Py_UOpsSymbolicExpression *null_sym =  _Py_UOpsSymbolicExpression_NewSingleton(ctx, PUSH_NULL, 0);
             sym_set_type(null_sym, PYNULL_TYPE, 0);
             PEEK(1) = null_sym;
             break;

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -1158,17 +1158,6 @@ uop_abstract_interpret(
         while (curr < end && (!_PyOpcode_ispure(curr->opcode) || curr->opcode == _SET_IP)) {
             DPRINTF(3, "impure opcode: %d\n", curr->opcode);
             int num_stack_inputs = _PyOpcode_num_popped((int)curr->opcode, (int)curr->oparg, false);
-            _Py_UOpsSymbolicExpression *impure_inst =
-                _Py_UOpsSymbolicExpression_NewFromArray(
-                    ctx,
-                    curr->opcode,
-                    curr->oparg,
-                    num_stack_inputs,
-                    &prev_store_stack[-(num_stack_inputs)]
-                );
-            if (impure_inst == NULL) {
-                goto error;
-            }
             // Adjust the stack and such
             int status = uop_abstract_interpret_single_inst(
                 co, curr, ctx,

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -1367,6 +1367,7 @@ emit_uops_from_pure_store(
         // Micro optimizations -- if LOAD_FAST then STORE_FAST, get rid of that
         if (prev_i.opcode == LOAD_FAST && prev_i.oparg == locals_i) {
             new_trace_len--;
+            DPRINTF(3, "LOAD_FAST to be followed by STORE_FAST, ignoring LOAD_FAST. \n");
             continue;
         }
         new_trace_len = emit_i(trace_writebuffer, new_trace_len, store_fast);
@@ -1418,7 +1419,7 @@ emit_uops_from_impure_store(
     for (Py_ssize_t i = 0; i < len; i++) {
         _PyUOpInstruction inst = impure_store->start[i];
         DPRINTF(2, "Emitting instruction at [%d] op: %s, oparg: %d, operand: %" PRIu64 " \n",
-                (int)(trace_len + i),
+                (int)(new_trace_len + i),
                 (inst.opcode >= 300 ? _PyOpcode_uop_name : _PyOpcode_OpName)[inst.opcode],
                 inst.oparg,
                 inst.operand);

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -59,8 +59,11 @@ typedef enum {
     PYINT_TYPE = 2,
     PYFLOAT_TYPE = 3,
     PYUNICODE_TYPE = 4,
-    GUARD_DORV_VALUES_TYPE = 5,
-    GUARD_DORV_VALUES_INST_ATTR_FROM_DICT_TYPE = 6,
+    PYNULL_TYPE = 5,
+    PYMETHOD_TYPE = 6,
+    GUARD_DORV_VALUES_TYPE = 7,
+    GUARD_DORV_VALUES_INST_ATTR_FROM_DICT_TYPE = 8,
+
 
     // GUARD_GLOBALS_VERSION_TYPE, / Environment check
     // GUARD_BUILTINS_VERSION_TYPE, // Environment check
@@ -989,13 +992,9 @@ uop_abstract_interpret_single_inst(
 
         case PUSH_NULL: {
             STACK_GROW(1);
-            PEEK(1) = _Py_UOpsSymbolicExpression_New(
-                ctx,
-                PUSH_NULL,
-                0,
-                NULL,
-                0
-            );
+            _Py_UOpsSymbolicExpression *null_sym =  _Py_UOpsSymbolicExpression_New(ctx, PUSH_NULL, 0, NULL, 0);
+            sym_set_type(null_sym, PYNULL_TYPE, 0);
+            PEEK(1) = null_sym;
             break;
         }
 

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -62,7 +62,7 @@ typedef enum {
     PYINT_TYPE = 2,
     PYFLOAT_TYPE = 3,
     PYUNICODE_TYPE = 4,
-    PYNULL_TYPE = 5,
+    NULL_TYPE = 5,
     PYMETHOD_TYPE = 6,
     GUARD_DORV_VALUES_TYPE = 7,
     GUARD_DORV_VALUES_INST_ATTR_FROM_DICT_TYPE = 8,
@@ -1022,7 +1022,7 @@ uop_abstract_interpret_single_inst(
         case PUSH_NULL: {
             STACK_GROW(1);
             _Py_UOpsSymbolicExpression *null_sym =  _Py_UOpsSymbolicExpression_NewSingleton(ctx, PUSH_NULL, 0);
-            sym_set_type(null_sym, PYNULL_TYPE, 0);
+            sym_set_type(null_sym, NULL_TYPE, 0);
             PEEK(1) = null_sym;
             break;
         }

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -88,7 +88,8 @@ SPECIALLY_HANDLED_ABSTRACT_INSTR = {
 
     # Shouldn't appear in abstract interpreter
     "_LOAD_FAST_NO_INCREF",
-    "_LOAD_CONST_IMMEDIATE"
+    "_LOAD_CONST_IMMEDIATE",
+    "_SWAP_AND_POP"
 }
 
 arg_parser = argparse.ArgumentParser(
@@ -865,9 +866,7 @@ class Generator(Analyzer):
             self.write_provenance_header()
             for instr in self.instrs.values():
                 instr = AbstractInstruction(instr.inst)
-                if (instr.name in SPECIALLY_HANDLED_ABSTRACT_INSTR
-                    # TODO handle variable stack opargs
-                    or any(eff.size for eff in instr.input_effects)):
+                if instr.name in SPECIALLY_HANDLED_ABSTRACT_INSTR:
                     continue
                 self.out.emit("")
                 with self.out.block(f"case {instr.name}:"):

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -85,6 +85,10 @@ SPECIALLY_HANDLED_ABSTRACT_INSTR = {
     "PUSH_NULL",
     "END_SEND",
     "SWAP",
+
+    # Shouldn't appear in abstract interpreter
+    "_LOAD_FAST_NO_INCREF",
+    "_LOAD_CONST_IMMEDIATE"
 }
 
 arg_parser = argparse.ArgumentParser(

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -139,7 +139,11 @@ class Instruction:
                 res = False
         return res
 
-    def write_variable_initializations(self, active_caches, out, tier):
+    def write_variable_initializations(
+            self,
+            active_caches: list[ActiveCacheEffect],
+            out: Formatter,
+            tier: int) -> None:
         # Write cache effect variable declarations and initializations
         for active in active_caches:
             ceffect = active.effect

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -500,6 +500,8 @@ def write_pokes(mgr: EffectManager, out: Formatter) -> None:
                 poke.effect,
             )
 
+def mangle_name(name: str) -> str:
+    return f"___{name}"
 
 def write_single_instr_for_abstract_interp(instr: Instruction, out: Formatter) -> None:
     try:
@@ -550,7 +552,7 @@ def _write_components_abstract_interp_pure_region(
             if peek.effect.name == UNUSED:
                 continue
             copy = dataclasses.replace(peek.effect)
-            copy.name = f"__{copy.name}"
+            copy.name = mangle_name(copy.name)
             out.assign(copy, peek.as_stack_effect())
 
         # Adjust stack
@@ -576,7 +578,7 @@ def _write_components_abstract_interp_pure_region(
             with out.block(f"if ({predicates or 0})"):
                 # Declare all variables
                 for name, eff in input_vars.items():
-                    out.declare(eff, StackEffect(f"get_const(__{name})"))
+                    out.declare(eff, StackEffect(f"get_const({mangle_name(name)})"))
                 out.declare(output_var, None)
                 mgr.instr.write_body(out, -4, mgr.active_caches, TIER_TWO, mgr.instr.family)
                 out.emit(
@@ -626,7 +628,7 @@ def _write_components_abstract_interp_guard_region(
             if peek.effect.name == UNUSED:
                 continue
             copy = dataclasses.replace(peek.effect)
-            copy.name = f"__{copy.name}"
+            copy.name = mangle_name(copy.name)
             out.assign(copy, peek.as_stack_effect())
         # If constant evaluation, directly evaluate the guard body
         predicates_str = " && ".join([f"is_const({var})" for var in mangled_input_vars])
@@ -634,7 +636,7 @@ def _write_components_abstract_interp_guard_region(
             with out.block(f"if ({predicates_str})"):
                 # Declare all variables
                 for name, eff in all_input_vars.items():
-                    out.declare(eff, StackEffect(f"get_const(__{name})"))
+                    out.declare(eff, StackEffect(f"get_const({mangle_name(name)})"))
                 mgr.instr.write_body(out, -4, mgr.active_caches, TIER_TWO, mgr.instr.family)
                 # Guard elimination - if we are successful, don't add it to the symexpr!
                 out.emit('DPRINTF(2, "const eliminated guard\\n");')
@@ -700,16 +702,15 @@ def _write_components_for_abstract_interp(
                     eff,
                 )
             else:
-                # TODO: Turn this into an error -- not supported
-                assert not eff.size, (
-                    f"Abstract interpreter does not support `{mgr.instr.name}` "
-                    f"due to sized input `{name}`")
+                if eff.size:
+                    assert not (inst.pure or inst.guard), \
+                        f"Abstract Interpreter: `{inst.name}` not supported due to sized input `{name}` in pure or guard"
                 all_input_vars[name] = eff
 
     # Mangle the input variables
-    mangled_input_vars = {f"__{k}": dataclasses.replace(v) for k, v in all_input_vars.items()}
+    mangled_input_vars = {mangle_name(k): dataclasses.replace(v) for k, v in all_input_vars.items()}
     for var in mangled_input_vars.values():
-        var.name = f"__{var.name}"
+        var.name = mangle_name(var.name)
         var.type = "_Py_UOpsSymbolicExpression *"
 
     if inst.pure:

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -629,9 +629,9 @@ def _write_components_abstract_interp_guard_region(
             copy.name = f"__{copy.name}"
             out.assign(copy, peek.as_stack_effect())
         # If constant evaluation, directly evaluate the guard body
-        predicates = " && ".join([f"is_const({var})" for var in mangled_input_vars])
-        if predicates:
-            with out.block(f"if ({predicates})"):
+        predicates_str = " && ".join([f"is_const({var})" for var in mangled_input_vars])
+        if predicates_str:
+            with out.block(f"if ({predicates_str})"):
                 # Declare all variables
                 for name, eff in all_input_vars.items():
                     out.declare(eff, StackEffect(f"get_const(__{name})"))

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -650,6 +650,7 @@ def _write_components_abstract_interp_guard_region(
             for peek in mgr.peeks:
                 if peek.effect.name == UNUSED:
                     continue
+                peek.effect.type = "_Py_UOpsSymbolicExpression *"
                 out.declare(peek.effect, peek.as_stack_effect())
             for input_var, input_effect in all_input_vars.items():
                 if (typ := input_effect.typeprop) is not None:


### PR DESCRIPTION
1. Removed a bunch of warnings
2. Removed dead code
3. Correct debugging message
4. Removed pass that removes duplicated `_SET_IP`
5. Added `PUSH_NULL` to abstract interp
6. Supported impure bytecode with sized operands
   - Changed some guards into impure
   - Supported 2 new types (`PYNULL_TYPE`, `PYMETHOD_TYPE`)